### PR TITLE
Bugfix/bug01. Fix docker server "Date()" error

### DIFF
--- a/Sources/App/routes.swift
+++ b/Sources/App/routes.swift
@@ -1,5 +1,6 @@
 import Fluent
 import Vapor
+import Foundation
 
 // MARK: - Functions
 

--- a/Sources/App/routes.swift
+++ b/Sources/App/routes.swift
@@ -1,6 +1,5 @@
 import Fluent
 import Vapor
-import Foundation
 
 // MARK: - Functions
 
@@ -8,7 +7,7 @@ func routes(_ app: Application) throws {
     let localStorage = LocalStorage()
 
     app.get { req async in
-        "GBShop Server running on [\(Date().ISO8601Format())]"
+        "GBShop Server running on [\(Date().description)]"
     }
 
     app.get("hello") { req async -> String in


### PR DESCRIPTION
1. Исправлена ошибка докер сервера 
```
#19 399.7 /build/Sources/App/routes.swift:10:45: error: value of type 'Date' has no member 'ISO8601Format'
#19 399.7         "GBShop Server running on [\(Date().ISO8601Format())]"
#19 399.7                                      ~~~~~~ ^~~~~~~~~~~~~
```